### PR TITLE
Made script compatible with engineering servers

### DIFF
--- a/generate_plot_from_tsv
+++ b/generate_plot_from_tsv
@@ -1,4 +1,4 @@
-#!/usr/bin/env gnuplot -c
+#!/usr/bin/env bash
 #
 # This is a simple script that will plot a TSV file as a line graph using
 # gnuplot.  You can run it like so, passing the name of the input TSV file
@@ -11,11 +11,11 @@
 #
 # Show usage information if arguments aren't present.
 #
-if (strlen(ARG1) == 0) print "Usage: " . ARG0 . " input.tsv output.jpg"; exit
-if (strlen(ARG2) == 0) print "Usage: " . ARG0 . " input.tsv output.jpg"; exit
+if [ "$#" -lt 2 ]; then
+    echo "Usage: ${0} input.tsv output.jpg"
+    exit 1;
+fi
 
-set terminal jpeg
-set output ARG2
-set style data lines
 
-plot ARG1
+
+gnuplot -e "set terminal jpeg;set output '${2}'; set style data lines;plot '${1}';"


### PR DESCRIPTION
Hi Dr. Hess!

The included gnuplot script `generate_plot_from_tsv` doesn't work on the engineering servers since they only have gnuplot version 4.6 (which doesn't provide any [command line argument](https://stackoverflow.com/a/31815067/8638218) support).

To get around this I made this a bash script using its command-line argument interface which just calls gnuplot with the appropriate commands via the -e flag.

I figured this would be a worthwhile change to since there are still a few recitation sections this week and it sounded like most groups in my recitation were having issues with getting gnu-plot to work.

Here are some screenshots showcasing it working on the flip servers:

example of script working on flip servers:
![image of script working](https://i.imgur.com/ysENXqg.png)

example graph generated by script:
![image of graph generated by bash script](https://i.imgur.com/ETNAfoM.png)

